### PR TITLE
fix: 🐛 Allow non-stretched images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 log.txt
 *.sublime-project
 *.sublime-workspace
+.DS_Store
 
 .idea/
 .vscode/

--- a/src/components/compare-row/compare-row.tsx
+++ b/src/components/compare-row/compare-row.tsx
@@ -125,7 +125,6 @@ export class CompareRow {
             <img
               src={this.imageASrc}
               class={this.imageAClass}
-              style={style}
               onLoad={this.diff.identical ? null : () => {
                 this.isImageALoaded = true;
                 this.imageAClass = 'has-loaded';
@@ -143,7 +142,6 @@ export class CompareRow {
             <img
               src={this.imageBSrc}
               class={this.imageBClass}
-              style={style}
               onLoad={this.diff.identical ? null : () => {
                 this.isImageBLoaded = true;
                 this.imageBClass = 'has-loaded';


### PR DESCRIPTION
Allow non stretched images in image compare view

This problem appeared multiple times, when the height of the components that were being tested changed.